### PR TITLE
add the devices section to the domain specification

### DIFF
--- a/lib/libvirt/spec/domain.rb
+++ b/lib/libvirt/spec/domain.rb
@@ -1,4 +1,5 @@
 require 'libvirt/spec/domain/os_booting'
+require 'libvirt/spec/domain/devices'
 
 module Libvirt
   module Spec
@@ -21,6 +22,8 @@ module Libvirt
       attr_accessor :on_poweroff
       attr_accessor :on_reboot
       attr_accessor :on_crash
+
+      attr_accessor :devices
 
       def initialize
         @os = OSBooting.new
@@ -53,6 +56,9 @@ module Libvirt
             xml.on_poweroff on_poweroff if on_poweroff
             xml.on_reboot on_reboot if on_reboot
             xml.on_crash on_crash if on_crash
+
+            # Devices
+            devices.to_xml(xml) if devices
           end
         end.to_xml
       end

--- a/lib/libvirt/spec/domain/characters.rb
+++ b/lib/libvirt/spec/domain/characters.rb
@@ -10,10 +10,8 @@ module Libvirt
       attr_accessor :source
       attr_accessor :target
 
-      def initialize(type, source = {}, target = {})
+      def initialize(type)
         @type = type
-        @source = source
-        @target = target
       end
 
       protected
@@ -22,11 +20,18 @@ module Libvirt
       # @return [String]
       def to_xml(element_name, parent = Nokogiri::XML::Builder.new)
         parent.send(element_name, :type => type) do |character|
-          character.source(@source)
-          character.target(@target)
+          elements(character)
         end
 
         parent.to_xml
+      end
+
+      def elements(character)
+        Array(source).each do |source_section|
+          character.source(source_section)
+        end if source
+
+        character.target(target) if target
       end
     end
 
@@ -40,11 +45,18 @@ module Libvirt
     end
 
     class Serial < Character
+      attr_accessor :protocol
+
       # Convert the Serial section to its XML representation
       #
       # @return [String]
       def to_xml(parent = Nokogiri::XML::Builder.new)
         super('serial', parent)
+      end
+
+      def elements(character)
+        super(character)
+        character.protocol(protocol) if protocol
       end
     end
 

--- a/lib/libvirt/spec/domain/characters.rb
+++ b/lib/libvirt/spec/domain/characters.rb
@@ -1,0 +1,69 @@
+module Libvirt
+  module Spec
+    # The character devices provide a different ways to interact with the
+    # virtual machine.
+    #
+    # There are four different representations that have to be used rather
+    # than Character.
+    class Character
+      attr_accessor :type
+      attr_accessor :source
+      attr_accessor :target
+
+      def initialize(type, source = {}, target = {})
+        @type = type
+        @source = source
+        @target = target
+      end
+
+      protected
+      # Convert the Character section to its XML representation
+      #
+      # @return [String]
+      def to_xml(element_name, parent = Nokogiri::XML::Builder.new)
+        parent.send(element_name, :type => type) do |character|
+          character.source(@source)
+          character.target(@target)
+        end
+
+        parent.to_xml
+      end
+    end
+
+    class Console < Character
+      # Convert the Console section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        super('console', parent)
+      end
+    end
+
+    class Serial < Character
+      # Convert the Serial section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        super('serial', parent)
+      end
+    end
+
+    class Parallel < Character
+      # Convert the Parallel section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        super('parallel', parent)
+      end
+    end
+
+    class Channel < Character
+      # Convert the Channel section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        super('channel', parent)
+      end
+    end
+  end
+end

--- a/lib/libvirt/spec/domain/devices.rb
+++ b/lib/libvirt/spec/domain/devices.rb
@@ -1,0 +1,75 @@
+require 'libvirt/spec/domain/characters'
+require 'libvirt/spec/domain/disk'
+
+module Libvirt
+  module Spec
+    # The Devices section of a domain specification indicates to libvirt how
+    # to configure the pieces provided to the guest machine.
+    #
+    # TODO: This section is still in earlier development, these are the
+    # subsections don't supported yet:
+    #   1. hostdev
+    #   2. interface
+    #   3. video
+    #   4. sound
+    #
+    class Devices
+      attr_accessor :emulator
+      attr_accessor :input
+      attr_accessor :graphics
+      attr_accessor :disk
+      attr_accessor :serial
+      attr_accessor :console
+      attr_accessor :watchdog
+      attr_accessor :memballoon
+
+      def initialize
+        @input, @graphics = []
+        @disk = []
+        @console, @serial, @parallel, @channel = []
+      end
+
+      # Convert the Devices section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        parent.devices do |devices|
+          devices.emulator emulator if emulator
+
+          input.each do |input_section|
+            devices.input(input_section)
+          end
+
+          graphics.each do |graphics_section|
+            devices.graphics(graphics_section)
+          end
+
+          disk.each do |disk_section|
+            disk_section.to_xml(devices)
+          end
+
+          console.each do |console_section|
+            console_section.to_xml(devices)
+          end
+
+          serial.each do |serial_section|
+            serial_section.to_xml(devices)
+          end
+
+          parallel.each do |parallel_section|
+            parallel_section.to_xml(devices)
+          end
+
+          channel.each do |channel_section|
+            channel_section.to_xml(devices)
+          end
+
+          devices.watchdog(watchdog) if watchdog
+          devices.memballoon(memballoon) if memballoon
+        end
+
+        parent.to_xml
+      end
+    end
+  end
+end

--- a/lib/libvirt/spec/domain/devices.rb
+++ b/lib/libvirt/spec/domain/devices.rb
@@ -20,6 +20,8 @@ module Libvirt
       attr_accessor :disk
       attr_accessor :serial
       attr_accessor :console
+      attr_accessor :parallel
+      attr_accessor :channel
       attr_accessor :watchdog
       attr_accessor :memballoon
 

--- a/lib/libvirt/spec/domain/disk.rb
+++ b/lib/libvirt/spec/domain/disk.rb
@@ -1,0 +1,41 @@
+require 'libvirt/spec/domain/encryptation'
+
+module Libvirt
+  module Spec
+    # The Disk section of a device specification indicates to libvirt how to
+    # configure any device that looks like a disk, floppy, harddisk, cdrom or paravirtualized driver.
+    class Disk
+      attr_accessor :type
+      attr_accessor :driver
+      attr_accessor :source
+      attr_accessor :target
+      attr_accessor :encryptation
+      attr_accessor :shareable
+      attr_accessor :serial
+
+      def initialize(type, shareable = false)
+        @type = type
+        @shareable = shareable
+        @driver, @source, @target = {}
+      end
+
+      # Convert the Disk section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        parent.disk(:type => type) do |disk|
+          disk.driver(driver) unless driver.empty?
+          disk.source(source)
+          disk.target(target)
+
+          encryptation.to_xml(disk) if encryptation
+
+          disk.shareable if shareable
+          disk.serial serial if serial
+        end
+
+        parent.to_xml
+      end
+    end
+  end
+end

--- a/lib/libvirt/spec/domain/encryptation.rb
+++ b/lib/libvirt/spec/domain/encryptation.rb
@@ -1,0 +1,26 @@
+module Libvirt
+  module Spec
+    # The encryptation section of a disk specification indicates to libvirt
+    # how the volumes attached can be encrypted.
+    class Encryptation
+      attr_accessor :format
+      attr_accessor :secret
+
+      def initialize(format, secret = {})
+        @format = format
+        @secret = secret
+      end
+
+      # Convert the Encriptation section to its XML representation
+      #
+      # @return [String]
+      def to_xml(parent = Nokogiri::XML::Builder.new)
+        parent.encryptation(:format => format) do |encryptation|
+          encryptation.secret(secret)
+        end
+
+        parent.to_xml
+      end
+    end
+  end
+end

--- a/lib/libvirt/spec/domain/encryptation.rb
+++ b/lib/libvirt/spec/domain/encryptation.rb
@@ -16,7 +16,7 @@ module Libvirt
       # @return [String]
       def to_xml(parent = Nokogiri::XML::Builder.new)
         parent.encryptation(:format => format) do |encryptation|
-          encryptation.secret(secret)
+          encryptation.secret(secret) unless secret.empty?
         end
 
         parent.to_xml

--- a/test/libvirt/domain_test.rb
+++ b/test/libvirt/domain_test.rb
@@ -100,7 +100,7 @@ Protest.describe("domain") do
     should "raise an error if the domain is already suspended" do
       @instance.suspend
       assert_raise(Libvirt::Exception::LibvirtError) {
-        @instance.suspend 
+        @instance.suspend
       }
     end
 

--- a/test/libvirt/spec/characters_test.rb
+++ b/test/libvirt/spec/characters_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+Protest.describe('Character device') do
+  context('a console') do
+    should "create an element 'console'" do
+      character = Libvirt::Spec::Console.new('tty').to_xml
+      assert_element character, '//console'
+    end
+  end
+
+  context('a serial port') do
+    should "create an element 'serial'" do
+      character = Libvirt::Spec::Serial.new('tcp').to_xml
+      assert_element character, '//serial'
+    end
+
+    should "include the protocol if exists" do
+      serial = Libvirt::Spec::Serial.new('tcp')
+      serial.protocol = {:type => 'raw'}
+      xml = serial.to_xml
+
+      assert_element xml, '//serial/protocol'
+      assert_xpath 'raw', xml, '//serial/protocol/@type'
+    end
+  end
+
+  context('a parallel port') do
+    should "create an element 'parallel'" do
+      character = Libvirt::Spec::Parallel.new('pty').to_xml
+      assert_element character, '//parallel'
+    end
+  end
+
+  context('a channel') do
+    should "create an element 'channel'" do
+      character = Libvirt::Spec::Channel.new('pty').to_xml
+      assert_element character, '//channel'
+    end
+  end
+
+  should "use the type parameter as attribute for the element" do
+    channel = Libvirt::Spec::Channel.new('pty').to_xml
+    assert_xpath 'pty', channel, '//channel/@type'
+  end
+
+  should "include the target if it's present" do
+    channel = Libvirt::Spec::Channel.new('pty')
+    channel.target = {:type => 'guestfwd', :address => '10.0.2.1', :port => '4600'}
+
+    assert_element channel.to_xml, '//channel/target'
+  end
+
+  should "include the source if it's present" do
+    channel = Libvirt::Spec::Channel.new('pty')
+    channel.source = {:mode => 'bind', :path => '/tmp/guestfwd'}
+
+    assert_element channel.to_xml, '//channel/source'
+  end
+
+  should "include all the sources if there are several" do
+    serial = Libvirt::Spec::Serial.new('udp')
+    serial.source = [
+      {:mode => 'bind', :host => '0.0.0.0', :service => '2445'},
+      {:mode => 'connect', :host => '0.0.0.0', :service => '2445'}
+    ]
+    assert_elements 2, serial.to_xml, '//serial/source'
+  end
+end

--- a/test/libvirt/spec/disk_test.rb
+++ b/test/libvirt/spec/disk_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+Protest.describe("Spec::Disk") do
+  setup do
+    @disk = Libvirt::Spec::Disk.new('file')
+  end
+
+  should "not be shareable by default" do
+    assert_not_element @disk.to_xml, '//disk/shareable'
+  end
+
+  should "be shareable if the parameter is true" do
+    disk = Libvirt::Spec::Disk.new('file', true).to_xml
+    assert_element disk, '//disk/shareable'
+  end
+
+  should "use the type as attribute for the xml element" do
+    assert_xpath 'file', @disk.to_xml, '//disk/@type'
+  end
+
+  should "include the driver if exists" do
+    @disk.driver = {:name => 'tap', :type => 'aio', :cache => 'default'}
+    assert_xpath 'tap', @disk.to_xml, '//disk/driver/@name'
+  end
+
+  should "include the source if exists" do
+    @disk.source = {:file => '/var/lib/xen/images/fv0'}
+    assert_xpath '/var/lib/xen/images/fv0', @disk.to_xml, '//disk/source/@file'
+  end
+
+  should "include the target if exists" do
+    @disk.target = {:dev => 'hda'}
+    assert_xpath 'hda', @disk.to_xml, '//disk/target/@dev'
+  end
+
+  should "include the encryptation if exists" do
+    @disk.encryptation = Libvirt::Spec::Encryptation.new('qcow')
+    assert_xpath 'qcow', @disk.to_xml, '//disk/encryptation/@type'
+  end
+
+  should "include the serial number if exist" do
+    @disk.serial = 'WD-WMAP9A966149'
+    assert_xpath 'WD-WMAP9A966149', @disk.to_xml, '//disk/serial'
+  end
+end

--- a/test/libvirt/spec/encryptation_test.rb
+++ b/test/libvirt/spec/encryptation_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+Protest.describe('Spec::Encryptation') do
+  should "use the required format as xml attribute" do
+    enc = Libvirt::Spec::Encryptation.new('qcow')
+    xml = Nokogiri::XML.parse(enc.to_xml)
+
+    assert_equal 'qcow', xml.at_xpath('//encryptation')['format']
+  end
+
+  should "use the optional hash to set the secret attributes" do
+    enc = Libvirt::Spec::Encryptation.new('qcow', {
+      :type => 'passphrase',
+      :uuid => 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a'
+    })
+    xml = Nokogiri::XML.parse(enc.to_xml)
+
+    secret = xml.at_xpath('//encryptation/secret')
+    assert_equal 'passphrase', secret['type']
+    assert_equal 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a', secret['uuid']
+  end
+
+  should "not set the secret without attributes" do
+    enc = Libvirt::Spec::Encryptation.new('qcow')
+    xml = Nokogiri::XML.parse(enc.to_xml)
+
+    assert_nil xml.at_xpath('//encryptation/secret')
+  end
+end

--- a/test/libvirt/spec/encryptation_test.rb
+++ b/test/libvirt/spec/encryptation_test.rb
@@ -11,7 +11,7 @@ Protest.describe('Spec::Encryptation') do
       :type => 'passphrase',
       :uuid => 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a'
     }).to_xml
-    
+
     assert_xpath 'passphrase', enc, '//encryptation/secret/@type'
     assert_xpath 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a', enc, '//encryptation/secret/@uuid'
   end

--- a/test/libvirt/spec/encryptation_test.rb
+++ b/test/libvirt/spec/encryptation_test.rb
@@ -2,28 +2,22 @@ require 'test_helper'
 
 Protest.describe('Spec::Encryptation') do
   should "use the required format as xml attribute" do
-    enc = Libvirt::Spec::Encryptation.new('qcow')
-    xml = Nokogiri::XML.parse(enc.to_xml)
-
-    assert_equal 'qcow', xml.at_xpath('//encryptation')['format']
+    enc = Libvirt::Spec::Encryptation.new('qcow').to_xml
+    assert_xpath 'qcow', enc, '//encryptation/@format'
   end
 
   should "use the optional hash to set the secret attributes" do
     enc = Libvirt::Spec::Encryptation.new('qcow', {
       :type => 'passphrase',
       :uuid => 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a'
-    })
-    xml = Nokogiri::XML.parse(enc.to_xml)
-
-    secret = xml.at_xpath('//encryptation/secret')
-    assert_equal 'passphrase', secret['type']
-    assert_equal 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a', secret['uuid']
+    }).to_xml
+    
+    assert_xpath 'passphrase', enc, '//encryptation/secret/@type'
+    assert_xpath 'c1f11a6d-8c5d-4a3e-ac7a-4e171c5e0d4a', enc, '//encryptation/secret/@uuid'
   end
 
   should "not set the secret without attributes" do
-    enc = Libvirt::Spec::Encryptation.new('qcow')
-    xml = Nokogiri::XML.parse(enc.to_xml)
-
-    assert_nil xml.at_xpath('//encryptation/secret')
+    enc = Libvirt::Spec::Encryptation.new('qcow').to_xml
+    assert_xpath nil, enc, '//encryptation/secret'
   end
 end

--- a/test/libvirt_helper.rb
+++ b/test/libvirt_helper.rb
@@ -1,0 +1,12 @@
+module Libvirt
+  module Assertions
+    def assert_xpath(expected, xml, xpath, msg = nil)
+      full_message = build_message(msg, '? at ? should be ?', xpath, xml, expected)
+      assert_block full_message do
+        value = Nokogiri::XML.parse(xml).at_xpath(xpath)
+        return value == expected if expected.nil?
+        return value.to_s == expected
+      end
+    end
+  end
+end

--- a/test/libvirt_helper.rb
+++ b/test/libvirt_helper.rb
@@ -19,6 +19,11 @@ module Libvirt
       end
     end
 
+    # Assert an element doesn't exist
+    def assert_not_element(xml, xpath)
+      assert_nil Nokogiri::XML.parse(xml).at_xpath(xpath)
+    end
+
     # Assert a valid number of elements
     def assert_elements(expected_size, xml, xpath, msg = nil)
       assert_equal expected_size, Nokogiri::XML.parse(xml).xpath(xpath).size

--- a/test/libvirt_helper.rb
+++ b/test/libvirt_helper.rb
@@ -1,5 +1,6 @@
 module Libvirt
   module Assertions
+    # Assert the value of an xpath expression is valid
     def assert_xpath(expected, xml, xpath, msg = nil)
       full_message = build_message(msg, '? at ? should be ?', xpath, xml, expected)
       assert_block full_message do
@@ -7,6 +8,20 @@ module Libvirt
         return value == expected if expected.nil?
         return value.to_s == expected
       end
+    end
+
+    # Assert an element exists
+    def assert_element(xml, xpath, msg = nil)
+      full_message = build_message(msg, 'element ? at ? not found', xpath, xml)
+      assert_block full_message do
+        !Nokogiri::XML.parse(xml).at_xpath(xpath).nil? &&
+          Nokogiri::XML.parse(xml).at_xpath(xpath).element?
+      end
+    end
+
+    # Assert a valid number of elements
+    def assert_elements(expected_size, xml, xpath, msg = nil)
+      assert_equal expected_size, Nokogiri::XML.parse(xml).xpath(xpath).size
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,10 @@ require "test/unit/assertions"
 require "protest"
 require "mocha"
 require "libvirt"
+require 'libvirt_helper'
 
 class Protest::TestCase
+  include Libvirt::Assertions
   include Test::Unit::Assertions
   include Mocha::API
 


### PR DESCRIPTION
Hey Mitchell, I just added the devices section to the spec, there are still some missing sections under devices but it's mostly complete. 

I'm getting a convention that I think we should follow, any primary element that requires an attribute gets it from the constructor, for instance the disk specification takes the type as mandatory parameter:

&lt;disk type='file'&gt;...&lt;/disk&gt;

Libvirt::Spec::Disk.new('file')

I've also seen that we don't have any test on the spec, I'll try to add some basic ones this weekend.
